### PR TITLE
fix: call first_name()/last_name() as methods in username() and name()

### DIFF
--- a/src/Country/Africa/IvoryCoastFakerGenerator.php
+++ b/src/Country/Africa/IvoryCoastFakerGenerator.php
@@ -326,15 +326,8 @@ class IvoryCoastFakerGenerator extends BaseGenerator implements FakerGeneratorIn
 
     public function username()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Générez un nombre aléatoire à ajouter au nom d'utilisateur
         $randomNumber = rand(100, 999);
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $username = strtolower($firstName . $lastName . $randomNumber);
+        $username = strtolower($this->first_name() . $this->last_name() . $randomNumber);
 
         return $username;
     }

--- a/src/Country/Africa/NigeriaFakerGenerator.php
+++ b/src/Country/Africa/NigeriaFakerGenerator.php
@@ -100,14 +100,7 @@ class NigeriaFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function name()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $name = strtolower($firstName . $lastName);
-
-        return $name;
+        return strtolower($this->first_name() . $this->last_name());
     }
 
     public function origins()

--- a/src/Country/Africa/SenegalFakerGenerator.php
+++ b/src/Country/Africa/SenegalFakerGenerator.php
@@ -340,15 +340,8 @@ class SenegalFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function username()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Générez un nombre aléatoire à ajouter au nom d'utilisateur
         $randomNumber = rand(100, 999);
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $username = strtolower($firstName . $lastName . $randomNumber);
+        $username = strtolower($this->first_name() . $this->last_name() . $randomNumber);
 
         return $username;
     }

--- a/src/Country/Africa/SouthAfricaFakerGenerator.php
+++ b/src/Country/Africa/SouthAfricaFakerGenerator.php
@@ -114,7 +114,7 @@ class SouthAfricaFakerGenerator extends BaseGenerator implements FakerGeneratorI
     return $origins[$randomIndex];
 }
 
-function region()
+public function region()
 {
     $regions = [
         "Gauteng", "KwaZulu-Natal", "Western Cape", "Eastern Cape", "Mpumalanga", "Limpopo", "North West", "Free State", "Northern Cape"
@@ -124,7 +124,7 @@ function region()
     return $randomRegion;
 }
 
-function city($region)
+public function city($region)
 {
     $villesParRegion = [
         "Gauteng" => ["Johannesburg", "Pretoria", "Soweto"],
@@ -153,7 +153,7 @@ public function cities()
     return $villes[array_rand($villes)];
 }
 
-function coordinates()
+public function coordinates()
 {
     // Limites géographiques de l'Afrique du Sud (latitude et longitude)
     $limites = [
@@ -311,15 +311,8 @@ public function phone()
 
     public function username()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Générez un nombre aléatoire à ajouter au nom d'utilisateur
         $randomNumber = rand(100, 999);
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $username = strtolower($firstName . $lastName . $randomNumber);
+        $username = strtolower($this->first_name() . $this->last_name() . $randomNumber);
 
         return $username;
     }

--- a/src/Country/America/CanadaFakerGenerator.php
+++ b/src/Country/America/CanadaFakerGenerator.php
@@ -357,15 +357,8 @@ class CanadaFakerGenerator extends BaseGenerator implements FakerGeneratorInterf
 
     public function username()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Générez un nombre aléatoire à ajouter au nom d'utilisateur
         $randomNumber = rand(100, 999);
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $username = strtolower($firstName . $lastName . $randomNumber);
+        $username = strtolower($this->first_name() . $this->last_name() . $randomNumber);
 
         return $username;
     }

--- a/src/Country/America/UnitedStatesFakerGenerator.php
+++ b/src/Country/America/UnitedStatesFakerGenerator.php
@@ -119,14 +119,7 @@ class UnitedStatesFakerGenerator extends BaseGenerator implements FakerGenerator
     }
     public function name()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $name = strtolower($firstName . $lastName);
-
-        return $name;
+        return strtolower($this->first_name() . $this->last_name());
     }
 
     function region()
@@ -339,15 +332,8 @@ class UnitedStatesFakerGenerator extends BaseGenerator implements FakerGenerator
 
     public function username()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Générez un nombre aléatoire à ajouter au nom d'utilisateur
         $randomNumber = rand(100, 999);
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $username = strtolower($firstName . $lastName . $randomNumber);
+        $username = strtolower($this->first_name() . $this->last_name() . $randomNumber);
 
         return $username;
     }

--- a/src/Country/Europe/GermanyFakerGenerator.php
+++ b/src/Country/Europe/GermanyFakerGenerator.php
@@ -358,28 +358,12 @@ class GermanyFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function username()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Générez un nombre aléatoire à ajouter au nom d'utilisateur
-        $randomNumber = rand(100, 999);
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $username = strtolower($firstName . $lastName . $randomNumber);
-
-        return $username;
+        return strtolower($this->first_name() . $this->last_name() . rand(100, 999));
     }
+
     public function name()
     {
-
-        $firstName = $this->first_name;
-        $lastName = $this->last_name;
-
-        // Concaténez le prénom, le nom de famille et le numéro aléatoire pour former le nom d'utilisateur
-        $name = strtolower($firstName . $lastName);
-
-        return $name;
+        return strtolower($this->first_name() . $this->last_name());
     }
 
     function product()


### PR DESCRIPTION
Property access via $this->first_name triggered Faker's __get magic returning null instead of invoking the generator method. Also adds missing public keyword to region(), city(), coordinates() in SouthAfricaFakerGenerator.