### PR TITLE
fix: remove version field from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "cupidontech/multi-faker",
     "description": "Package for generating Faker by country",
-    "version": "1.1.0",
     "type": "library",
     "homepage" : "https://github.com/Dilane05/multi-faker",
     "license": "MIT",


### PR DESCRIPTION
Packagist ignores git tags when a hardcoded version field is present and conflicts with the tag name.