### PR TITLE
docs: enhance README with examples, comparisons and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # multi-faker
 
-Country-specific fake data generator for PHP — with built-in support for French-speaking African countries and more.
+**The missing Faker locale for Africa.**
+
+Generate realistic fake data for African and international applications.
+
+```php
+use Cupidontech\MultiFaker\MultiFakerGenerator;
+
+$faker = new MultiFakerGenerator('Cameroon');
+
+echo $faker->name();     // Jean Baptiste Ndzié
+echo $faker->phone();    // +237 677 123 456
+echo $faker->address();  // Bonamoussadi, Douala
+```
 
 [![Tests](https://github.com/Dilane05/multi-faker/actions/workflows/tests.yml/badge.svg)](https://github.com/Dilane05/multi-faker/actions/workflows/tests.yml)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/cupidontech/multi-faker)](https://packagist.org/packages/cupidontech/multi-faker)
@@ -8,40 +20,99 @@ Country-specific fake data generator for PHP — with built-in support for Frenc
 [![PHP Version](https://img.shields.io/packagist/php-v/cupidontech/multi-faker)](https://packagist.org/packages/cupidontech/multi-faker)
 [![GitHub License](https://img.shields.io/github/license/Dilane05/multi-faker)](LICENSE.md)
 
+---
+
 ## Table of Contents
 
-- [Why multi-faker?](#why-multi-faker)
-- [Supported countries](#supported-countries)
+- [The Problem](#the-problem)
+- [FakerPHP vs multi-faker](#fakephp-vs-multi-faker)
+- [Supported Countries](#supported-countries)
+- [Features](#features)
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Usage](#usage)
-- [Available methods](#available-methods)
+- [Example Output](#example-output)
+- [Available Methods](#available-methods)
+- [Roadmap](#roadmap)
 - [Contributions](#contributions)
 - [License](#license)
 
-## Why multi-faker?
+---
 
-[FakerPHP](https://fakerphp.org/) covers dozens of locales but has **no locale** for French-speaking African countries (Cameroon, Ivory Coast, Senegal, …). multi-faker fills that gap with realistic, country-specific names, phone numbers, cities, regions, and more.
+## The Problem
 
-## Supported countries
+FakerPHP supports many locales but provides no realistic datasets for most African countries.
+
+| Country | FakerPHP | multi-faker |
+|---------|----------|-------------|
+| Cameroon | ❌ | ✅ |
+| Senegal | ❌ | ✅ |
+| Ivory Coast | ❌ | ✅ |
+| Nigeria | Limited | ✅ |
+| South Africa | Limited | ✅ |
+| France | ✅ | ✅ |
+| USA | ✅ | ✅ |
+
+As a result, developers often seed African applications with unrealistic names, cities, and phone numbers. multi-faker solves this with country-specific generators built from real local datasets.
+
+---
+
+## FakerPHP vs multi-faker
+
+| Feature | FakerPHP | multi-faker |
+|---------|----------|-------------|
+| Local names | ❌ (for Africa) | ✅ |
+| Local phone formats | ❌ | ✅ |
+| Local regions | ❌ | ✅ |
+| Local cities | ❌ | ✅ |
+| GPS coordinates | ❌ | ✅ |
+| Switch country at runtime | ❌ | ✅ |
+| Laravel integration | ✅ | ✅ |
+
+---
+
+## Supported Countries
 
 | Country | Key |
 |---------|-----|
-| Cameroon | `Cameroon` |
-| Ivory Coast | `IvoryCoast` |
-| Nigeria | `Nigeria` |
-| Senegal | `Senegal` |
-| South Africa | `SouthAfrica` |
-| Canada | `Canada` |
-| United States | `UnitedStates` |
-| France | `France` |
-| Germany | `Germany` |
+| 🇨🇲 Cameroon | `Cameroon` |
+| 🇨🇮 Ivory Coast | `IvoryCoast` |
+| 🇳🇬 Nigeria | `Nigeria` |
+| 🇸🇳 Senegal | `Senegal` |
+| 🇿🇦 South Africa | `SouthAfrica` |
+| 🇨🇦 Canada | `Canada` |
+| 🇺🇸 United States | `UnitedStates` |
+| 🇫🇷 France | `France` |
+| 🇩🇪 Germany | `Germany` |
+
+---
+
+## Features
+
+| Feature | Supported |
+|---------|-----------|
+| First & last names | ✅ |
+| Full names & usernames | ✅ |
+| Email addresses | ✅ |
+| Phone numbers (local format) | ✅ |
+| Addresses | ✅ |
+| Regions & cities | ✅ |
+| GPS coordinates | ✅ |
+| Company names | ✅ |
+| Products & food items | ✅ |
+| Dates | ✅ |
+| Passwords & credit cards | ✅ |
+| Random text | ✅ |
+
+---
 
 ## Requirements
 
 - PHP 8.1+
 - Laravel 9, 10, or 11 (optional — works standalone too)
+
+---
 
 ## Installation
 
@@ -57,6 +128,8 @@ Laravel auto-discovers the service provider. For older versions of Laravel, add 
 ],
 ```
 
+---
+
 ## Configuration
 
 Set the default country in your `.env` file:
@@ -67,6 +140,8 @@ MULTI_FAKER_DEFAULT_COUNTRY=Cameroon
 
 Accepted values: `Cameroon`, `IvoryCoast`, `Nigeria`, `Senegal`, `SouthAfrica`, `Canada`, `UnitedStates`, `France`, `Germany`.
 
+---
+
 ## Usage
 
 ### Standalone
@@ -76,9 +151,9 @@ use Cupidontech\MultiFaker\MultiFakerGenerator;
 
 $faker = new MultiFakerGenerator('Cameroon');
 
-echo $faker->first_name();   // e.g. "Amina"
-echo $faker->phone();        // e.g. "+237 655 123 456"
-echo $faker->email();        // e.g. "amina.nkou@gmail.com"
+echo $faker->first_name();  // e.g. "Amina"
+echo $faker->phone();       // e.g. "+237 655 123 456"
+echo $faker->email();       // e.g. "amina.nkou@gmail.com"
 ```
 
 ### Laravel (dependency injection)
@@ -102,6 +177,20 @@ class SeedController extends Controller
 }
 ```
 
+### Laravel Seeder
+
+```php
+use Cupidontech\MultiFaker\MultiFakerGenerator;
+
+$faker = new MultiFakerGenerator('Senegal');
+
+User::factory()->count(100)->create([
+    'name'  => $faker->name(),
+    'phone' => $faker->phone(),
+    'city'  => $faker->cities(),
+]);
+```
+
 ### Switching country at runtime
 
 ```php
@@ -112,7 +201,42 @@ $faker = new MultiFakerGenerator('France');
 echo $faker->first_name(); // French first name
 ```
 
-## Available methods
+---
+
+## Example Output
+
+### 🇨🇲 Cameroon
+
+```
+name()      → Jean Baptiste Ndzié
+phone()     → +237 677 123 456
+address()   → Bonamoussadi, Douala
+region()    → Littoral
+city()      → Bafoussam
+email()     → jean.ndzié@gmail.com
+```
+
+### 🇸🇳 Senegal
+
+```
+name()      → Mamadou Diop
+phone()     → +221 77 123 45 67
+region()    → Dakar
+city()      → Thiès
+```
+
+### 🇳🇬 Nigeria
+
+```
+name()      → Chukwuemeka Obi
+phone()     → +234 803 123 4567
+region()    → Lagos
+city()      → Abuja
+```
+
+---
+
+## Available Methods
 
 All generators implement the same interface, regardless of country.
 
@@ -120,9 +244,9 @@ All generators implement the same interface, regardless of country.
 // Identity
 $faker->first_name();
 $faker->last_name();
-$faker->name();          // full name (lowercased)
-$faker->username();      // e.g. "aminankou742"
-$faker->gender();        // "Male" or "Female"
+$faker->name();           // full name
+$faker->username();       // e.g. "aminankou742"
+$faker->gender();         // "Male" or "Female"
 
 // Contact
 $faker->email();
@@ -131,13 +255,13 @@ $faker->phone();
 // Location
 $faker->address();
 $faker->region();
-$faker->city($region);   // city in the given region
-$faker->cities();        // random city from all regions
-$faker->coordinates();   // ['latitude' => ..., 'longitude' => ...]
+$faker->city($region);    // city in the given region
+$faker->cities();         // random city from all regions
+$faker->coordinates();    // ['latitude' => ..., 'longitude' => ...]
 
 // Date & security
-$faker->date();                                        // default: last 30 years
-$faker->date('-10 years', 'now', 'd/m/Y');            // custom range & format
+$faker->date();                              // default: last 30 years
+$faker->date('-10 years', 'now', 'd/m/Y');  // custom range & format
 $faker->password();
 $faker->creditCardNumber();
 
@@ -145,8 +269,32 @@ $faker->creditCardNumber();
 $faker->companyName();
 $faker->product();
 $faker->food();
-$faker->text(100);       // random text of given length
+$faker->text(100);        // random text of given length
 ```
+
+---
+
+## Roadmap
+
+- [x] 🇨🇲 Cameroon
+- [x] 🇨🇮 Ivory Coast
+- [x] 🇳🇬 Nigeria
+- [x] 🇸🇳 Senegal
+- [x] 🇿🇦 South Africa
+- [x] 🇫🇷 France
+- [x] 🇨🇦 Canada
+- [x] 🇺🇸 United States
+- [x] 🇩🇪 Germany
+- [ ] 🇨🇬 Congo
+- [ ] 🇬🇦 Gabon
+- [ ] 🇧🇯 Benin
+- [ ] 🇹🇬 Togo
+- [ ] 🇧🇫 Burkina Faso
+- [ ] 🇲🇱 Mali
+- [ ] 🇬🇭 Ghana
+- [ ] 🇰🇪 Kenya
+
+---
 
 ## Contributions
 
@@ -159,6 +307,8 @@ We welcome contributions. Please follow the git flow below:
 5. Once reviewed and merged to `dev`, a maintainer will cut a release to `main`.
 
 To add a new country, see the [CLAUDE.md](CLAUDE.md) guide.
+
+---
 
 ## License
 


### PR DESCRIPTION
Adds quick-start example at top, problem/comparison tables vs FakerPHP, feature table, country flags, example output per country, Laravel seeder example, and a roadmap. Slogan changed to 'The missing Faker locale for Africa.'