### PR TITLE
feat: rich datasets — university, district, licensePlate, nationalId …

### DIFF
--- a/src/Contracts/FakerGeneratorInterface.php
+++ b/src/Contracts/FakerGeneratorInterface.php
@@ -22,4 +22,8 @@ interface FakerGeneratorInterface
     public function username();
     public function product();
     public function food();
+    public function university();
+    public function district();
+    public function licensePlate();
+    public function nationalId();
 }

--- a/src/Country/Africa/CameroonFakerGenerator.php
+++ b/src/Country/Africa/CameroonFakerGenerator.php
@@ -146,15 +146,15 @@ class CameroonFakerGenerator extends BaseGenerator implements FakerGeneratorInte
 
     public function phone()
     {
-        $prefix     = '+2376';
-        $firstDigit = [6, 5, 7, 9, 8][rand(0, 4)];
-        $rest       = '';
-
-        for ($i = 0; $i < 7; $i++) {
-            $rest .= rand(0, 9);
-        }
-
-        return $prefix . $firstDigit . $rest;
+        $prefixes = [
+            '650', '651', '652', '653', '654', '655', '656', '657', '658', '659',
+            '670', '671', '672', '673', '674', '675', '676', '677', '678', '679',
+            '690', '691', '692', '693', '694', '695', '696', '697', '698', '699',
+            '660', '661', '662', '663', '664', '665',
+            '620', '621', '622',
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+237 %s %03d %03d', $prefix, rand(0, 999), rand(0, 999));
     }
 
     public function email()
@@ -181,10 +181,17 @@ class CameroonFakerGenerator extends BaseGenerator implements FakerGeneratorInte
 
     public function companyName()
     {
-        $prefixes = ['Société', 'Entreprise', 'Groupe', 'Compagnie', 'OM', 'MOMO', 'ODC', 'EU MOBILE MONEY', 'BICEC', 'UBA', 'FINESS', 'GLOBAL', 'BUCA', 'ACTIVA', 'MEMPHYS', 'SABITOO', 'ANNA', 'G6K', 'K-RISMA', 'BOCOM', 'TOTAL', 'NEXTTEL', 'YOOME'];
-        $suffixes = ['Ltd', 'SA', 'SARL', 'EURL', 'SPRL'];
-
-        return $prefixes[array_rand($prefixes)] . ' ' . $suffixes[array_rand($suffixes)];
+        $companies = [
+            'MTN Cameroon', 'Orange Cameroun', 'Camtel', 'Nexttel Cameroun',
+            'Afriland First Bank', 'Société Générale Cameroun', 'UBA Cameroun',
+            'Ecobank Cameroun', 'BICEC', 'SCB Cameroun', 'BGFI Bank Cameroun',
+            'SABC', 'Guinness Cameroun', 'CICAM', 'Total Énergies Cameroun',
+            'Canal+ Cameroun', 'Campost', 'SCDP', 'Camair-Co', 'CFAO Motors',
+            'Tradex', 'Express Exchange', 'Chanas Assurances', 'Activa Assurances',
+            'CCA Bank', 'Crédit du Sahel', 'National Financial Credit (NFC)',
+            'Boulangerie Nouvelle', 'Pharmacie de la Paix', 'Imprimerie Saint-Paul',
+        ];
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -233,5 +240,50 @@ class CameroonFakerGenerator extends BaseGenerator implements FakerGeneratorInte
         ];
 
         return $plats[array_rand($plats)];
+    }
+
+    public function university()
+    {
+        $universities = [
+            'Université de Douala', 'Université de Yaoundé I', 'Université de Yaoundé II (Soa)',
+            'Université de Dschang', 'Université de Ngaoundéré', 'Université de Buea',
+            'Université de Maroua', 'Université de Bamenda',
+            'École Nationale Supérieure Polytechnique (ENSP)',
+            'École Nationale d\'Administration et de Magistrature (ENAM)',
+            'Institut Supérieur de Management de Yaoundé (ISM)',
+            'Université Catholique d\'Afrique Centrale (UCAC)',
+            'Institut des Relations Internationales du Cameroun (IRIC)',
+            'École Supérieure des Sciences et Techniques de l\'Information (ESSTIC)',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Akwa', 'Bonanjo', 'Bonapriso', 'Bonamoussadi', 'Bali', 'Deido',
+            'Logbessou', 'Makepe', 'Ndokotti', 'Bépanda', 'Ndog-Bong', 'Kotto',
+            'Logpom', 'Sodiko', 'Mboppi', 'Ndog-Passi', 'Nkol-Eton',
+            'Bastos', 'Tsinga', 'Mvan', 'Ekounou', 'Emana', 'Nkolbisson',
+            'Ngousso', 'Efoulan', 'Mvog-Ada', 'Mendong', 'Elig-Essono',
+            'Nlongkak', 'Santa Barbara', 'Omnisports', 'Essos', 'Mimboman',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $regions = ['LT', 'CE', 'NO', 'EN', 'AD', 'NW', 'SW', 'SU', 'ES', 'OU'];
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $region  = $regions[array_rand($regions)];
+        $number  = str_pad(rand(1, 9999), 4, '0', STR_PAD_LEFT);
+        $suffix  = $letters[rand(0, strlen($letters) - 1)] . $letters[rand(0, strlen($letters) - 1)];
+        return $region . ' ' . $number . ' ' . $suffix;
+    }
+
+    public function nationalId()
+    {
+        $letter = chr(rand(65, 90));
+        return $letter . str_pad(rand(1, 99999999), 8, '0', STR_PAD_LEFT);
     }
 }

--- a/src/Country/Africa/IvoryCoastFakerGenerator.php
+++ b/src/Country/Africa/IvoryCoastFakerGenerator.php
@@ -231,18 +231,13 @@ class IvoryCoastFakerGenerator extends BaseGenerator implements FakerGeneratorIn
 
     public function phone()
     {
-        $prefix = '+225';
-
-        // Générez le premier chiffre aléatoire parmi 01, 02, 03, 04, 05, 06 ou 07
-        $firstDigit = '0' . [1, 2, 3, 4, 5, 6, 7][rand(0, 6)];
-
-        // Générez les 6 derniers chiffres aléatoires
-        $secondPart = '';
-        for ($i = 0; $i < 6; $i++) {
-            $secondPart .= rand(0, 9);
-        }
-
-        return $prefix . $firstDigit  . $secondPart;
+        $prefixes = [
+            '07', '27',  // Orange CI
+            '05', '25',  // MTN CI
+            '01', '21',  // Moov Africa
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+225 %s %02d %02d %02d %02d', $prefix, rand(10, 99), rand(10, 99), rand(10, 99), rand(10, 99));
     }
 
     public function email()
@@ -276,27 +271,16 @@ class IvoryCoastFakerGenerator extends BaseGenerator implements FakerGeneratorIn
 
     public function companyName()
     {
-        $prefixes = [
-            'Ivoirienne', 'Abidjan', 'Cocody', 'Marcory', 'Plateau', 'Treichville', 'Yopougon', 'Adjamé', 'Koumassi', 'Port-Bouët',
-            'Treichville', 'Attécoubé', 'Korhogo', 'Bouaké', 'Daloa', 'Yamoussoukro', 'San Pedro', 'Man', 'Divo', 'Gagnoa',
-            'Abengourou', 'Bouaflé', 'Sassandra', 'Grand-Bassam', 'Bondoukou', 'Odienné', 'Seguela', 'Agboville', 'Bouna', 'Issia',
-            'Ferkessédougou', 'Dabou', 'Bangolo', 'Tingrela', 'Sinfra', 'Danané', 'Katiola', 'Toumodi', 'Daoukro', 'Sakassou',
-            'Tanda', 'Bonoua', 'Bingerville', 'Béoumi', 'Alepe', 'Adiaké', 'Lakota', 'Tiassalé', 'Djékanou', 'Facobly'
+        $companies = [
+            'MTN Côte d\'Ivoire', 'Orange Côte d\'Ivoire', 'Moov Africa Côte d\'Ivoire',
+            'BICICI', 'SGBCI', 'Ecobank Côte d\'Ivoire', 'NSIA Banque',
+            'Société Ivoirienne de Banque (SIB)', 'Banque Atlantique CI', 'UBA CI',
+            'Brasseries Ivoiriennes', 'Solibra', 'Air Côte d\'Ivoire',
+            'SODECI', 'CIE', 'Canal+ Côte d\'Ivoire', 'Total CI',
+            'SIFCA', 'SUCRIVOIRE', 'Nestlé CI', 'CFAO CI',
+            'Pharmacie Nationale', 'Université Mohammed VI Polytechnique', 'Wave CI',
         ];
-
-
-        $suffixes = [
-            'Ltd', 'PLC', 'LLC', 'LLP', 'Limited', 'PLC', 'LLC', 'LLP', 'Holdings', 'Group', 'Corp', 'Corporation', 'Services',
-            'Enterprises', 'Solutions', 'Global', 'Ventures', 'Industries', 'Integrators', 'Associates', 'Incorporated', 'Partners',
-            'Resources', 'Technologies', 'Logistics', 'Management', 'Consulting', 'Enterprises', 'Solutions', 'Group', 'Industries',
-            'Systems', 'Enterprises', 'Holdings', 'Development', 'Sustainable', 'Enterprises', 'Innovations', 'Foundation'
-
-        ];
-
-        $prefix = $prefixes[rand(0, count($prefixes) - 1)];
-        $suffix = $suffixes[rand(0, count($suffixes) - 1)];
-
-        return "$prefix $suffix";
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -441,5 +425,46 @@ class IvoryCoastFakerGenerator extends BaseGenerator implements FakerGeneratorIn
         $nomPlat = $platsIvoiriens[array_rand($platsIvoiriens)];
 
         return $nomPlat;
+    }
+
+    public function university()
+    {
+        $universities = [
+            'Université Félix Houphouët-Boigny (Cocody)',
+            'Université Abobo-Adjamé', 'Université Jean Lorougnon Guédé (Daloa)',
+            'Université Alassane Ouattara (Bouaké)',
+            'Université Peleforo Gon Coulibaly (Korhogo)',
+            'Institut National Polytechnique Félix Houphouët-Boigny (INPHB)',
+            'École Nationale Supérieure d\'Ingénieurs (ENSI)',
+            'ESATIC', 'INPHB Yamoussoukro', 'Université de Man',
+            'Institut Supérieur des Sciences et Technologie d\'Abidjan (ISSTA)',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Cocody', 'Plateau', 'Marcory', 'Treichville', 'Yopougon',
+            'Abobo', 'Adjamé', 'Attécoubé', 'Koumassi', 'Port-Bouët',
+            'Bingerville', 'Riviera', '2 Plateaux', 'Angré', 'Danga',
+            'Blockhaus', 'Zone 4', 'Zone 3', 'Biétry', 'Vridi',
+            'Songon', 'Anyama', 'Alepo',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $l1 = $letters[rand(0, strlen($letters) - 1)];
+        $l2 = $letters[rand(0, strlen($letters) - 1)];
+        $number = str_pad(rand(1, 9999), 4, '0', STR_PAD_LEFT);
+        return $l1 . $l2 . ' ' . $number . ' CI';
+    }
+
+    public function nationalId()
+    {
+        return str_pad(rand(1, 9999999999), 10, '0', STR_PAD_LEFT);
     }
 }

--- a/src/Country/Africa/NigeriaFakerGenerator.php
+++ b/src/Country/Africa/NigeriaFakerGenerator.php
@@ -258,19 +258,14 @@ class NigeriaFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function phone()
     {
-        $prefix = '+234';
-
-            // Générez le premier chiffre aléatoire parmi 7, 9 ou 8
-        $firstDigit = [7, 9, 8][rand(0, 2)];
-
-
-        // Générez les 5 derniers chiffres aléatoires
-        $secondPart = '';
-        for ($i = 0; $i < 10; $i++) {
-            $secondPart .= rand(0, 9);
-        }
-
-        return $prefix . $firstDigit  . $secondPart;
+        $prefixes = [
+            '0803', '0806', '0813', '0816', '0903', '0906',  // MTN
+            '0805', '0807', '0815', '0905',                   // Glo
+            '0802', '0808', '0812', '0902', '0907',           // Airtel
+            '0809', '0817', '0818', '0909',                   // 9mobile
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+234 %s %04d %04d', $prefix, rand(1000, 9999), rand(1000, 9999));
     }
 
     public function email()
@@ -304,26 +299,16 @@ class NigeriaFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function companyName()
     {
-        $prefixes = [
-
-            'Nigerian', 'Lagos', 'Abuja', 'Kano', 'Zenith', 'First', 'Access', 'Guaranty', 'Union', 'United', 'Fidelity',
-            'Diamond', 'Skye', 'Stanbic', 'Standard', 'Eco', 'Heritage', 'Keystone', 'Unity', 'Mainstreet', 'Wema',
-            'Jaiz', 'Sterling', 'SunTrust', 'Providus', 'Trust', 'Coronation', 'ASO', 'Capital', 'Sovereign', 'Fortis',
-            'Citi', 'Polaris', 'Rand', 'Ecobank', 'Unity', 'Enterprise', 'Legacy', 'Jaiz', 'Sun', 'Spring', 'VFD', 'Cititrust'
-
+        $companies = [
+            'MTN Nigeria', 'Airtel Nigeria', 'Glo Mobile', '9mobile',
+            'Dangote Group', 'Zenith Bank', 'Access Bank', 'First Bank Nigeria',
+            'GTBank', 'UBA Nigeria', 'NNPC', 'Nigerian Breweries', 'Nestlé Nigeria',
+            'Flour Mills Nigeria', 'Total Nigeria', 'Fidelity Bank', 'Stanbic IBTC',
+            'Union Bank', 'Wema Bank', 'Sterling Bank', 'Polaris Bank', 'Ecobank Nigeria',
+            'Coronation Bank', 'Providus Bank', 'SunTrust Bank', 'Globacom Nigeria',
+            'Innoson Vehicle Manufacturing', 'Dangote Cement', 'BUA Cement', 'Lafarge Africa',
         ];
-        $suffixes = [
-            'Ltd', 'PLC', 'LLC', 'LLP', 'Limited', 'PLC', 'LLC', 'LLP', 'Holdings', 'Group', 'Corp', 'Corporation', 'Services',
-            'Enterprises', 'Solutions', 'Global', 'Ventures', 'Industries', 'Integrators', 'Associates', 'Incorporated', 'Partners',
-            'Resources', 'Technologies', 'Logistics', 'Management', 'Consulting', 'Enterprises', 'Solutions', 'Group', 'Industries',
-            'Systems', 'Enterprises', 'Holdings', 'Development', 'Sustainable', 'Enterprises', 'Innovations', 'Foundation'
-
-        ];
-
-        $prefix = $prefixes[rand(0, count($prefixes) - 1)];
-        $suffix = $suffixes[rand(0, count($suffixes) - 1)];
-
-        return "$prefix $suffix";
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -479,5 +464,47 @@ class NigeriaFakerGenerator extends BaseGenerator implements FakerGeneratorInter
         $nomPlat = $platsNigerian[array_rand($platsNigerian)];
 
         return $nomPlat;
+    }
+
+    public function university()
+    {
+        $universities = [
+            'University of Lagos (UNILAG)', 'University of Ibadan',
+            'Obafemi Awolowo University (OAU)', 'University of Nigeria Nsukka (UNN)',
+            'Ahmadu Bello University (ABU)', 'University of Benin (UNIBEN)',
+            'Lagos State University (LASU)', 'Covenant University',
+            'Babcock University', 'Pan-Atlantic University',
+            'Nnamdi Azikiwe University', 'University of Port Harcourt (UNIPORT)',
+            'Bayero University Kano (BUK)', 'Federal University of Technology Minna',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Victoria Island', 'Lekki', 'Ikoyi', 'Surulere', 'Ikeja',
+            'Yaba', 'Apapa', 'Maryland', 'Festac Town', 'Ajah',
+            'Gbagada', 'Magodo', 'Ojota', 'Ketu', 'Mushin', 'Oshodi',
+            'Maitama', 'Wuse', 'Garki', 'Asokoro', 'Gwarinpa',
+            'Jabi', 'Lugbe', 'Kubwa', 'Bwari', 'Kuje',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $states = ['LAG', 'ABJ', 'KAN', 'PHC', 'IBD', 'ABK', 'ENU', 'KAD', 'JOS', 'BEN'];
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $state = $states[array_rand($states)];
+        $number = rand(100, 999);
+        $l1 = $letters[rand(0, strlen($letters) - 1)];
+        $l2 = $letters[rand(0, strlen($letters) - 1)];
+        return $state . '-' . $number . $l1 . $l2;
+    }
+
+    public function nationalId()
+    {
+        return str_pad(rand(10000000000, 99999999999), 11, '0', STR_PAD_LEFT);
     }
 }

--- a/src/Country/Africa/SenegalFakerGenerator.php
+++ b/src/Country/Africa/SenegalFakerGenerator.php
@@ -245,18 +245,13 @@ class SenegalFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function phone()
     {
-        $prefix = '+221'; // Préfixe téléphonique du Sénégal
-    
-        // Générez le premier chiffre aléatoire parmi 70, 76, 77, 78 ou 79 (indicatifs de réseau mobile au Sénégal)
-        $firstDigit = '7' . [0, 6, 7, 8, 9][rand(0, 4)];
-    
-        // Générez les 6 derniers chiffres aléatoires
-        $secondPart = '';
-        for ($i = 0; $i < 6; $i++) {
-            $secondPart .= rand(0, 9);
-        }
-    
-        return $prefix . $firstDigit  . $secondPart;
+        $prefixes = [
+            '77', '78',  // Orange Sénégal
+            '76',        // Free Sénégal
+            '70',        // Expresso
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+221 %s %03d %02d %02d', $prefix, rand(100, 999), rand(10, 99), rand(10, 99));
     }
     
     public function email()
@@ -290,27 +285,15 @@ class SenegalFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function companyName()
     {
-        $prefixes = [
-            'Ivoirienne', 'Abidjan', 'Cocody', 'Marcory', 'Plateau', 'Treichville', 'Yopougon', 'Adjamé', 'Koumassi', 'Port-Bouët',
-            'Treichville', 'Attécoubé', 'Korhogo', 'Bouaké', 'Daloa', 'Yamoussoukro', 'San Pedro', 'Man', 'Divo', 'Gagnoa',
-            'Abengourou', 'Bouaflé', 'Sassandra', 'Grand-Bassam', 'Bondoukou', 'Odienné', 'Seguela', 'Agboville', 'Bouna', 'Issia',
-            'Ferkessédougou', 'Dabou', 'Bangolo', 'Tingrela', 'Sinfra', 'Danané', 'Katiola', 'Toumodi', 'Daoukro', 'Sakassou',
-            'Tanda', 'Bonoua', 'Bingerville', 'Béoumi', 'Alepe', 'Adiaké', 'Lakota', 'Tiassalé', 'Djékanou', 'Facobly'
+        $companies = [
+            'Orange Sénégal', 'Free Sénégal', 'Sonatel', 'Expresso Sénégal',
+            'Senelec', 'SGBS', 'Ecobank Sénégal', 'CBAO', 'Banque Atlantique SN',
+            'UBA Sénégal', 'Orabank Sénégal', 'BIS', 'BNDE', 'Crédit du Sénégal',
+            'Total Sénégal', 'Air Sénégal', 'Canal+ Sénégal', 'Wave Sénégal',
+            'SAED', 'SONACOS', 'SUNEOR', 'Patisen', 'NMA Sanders',
+            'DHL Sénégal', 'Bolloré Transport & Logistics SN', 'COSEC',
         ];
-
-
-        $suffixes = [
-            'Ltd', 'PLC', 'LLC', 'LLP', 'Limited', 'PLC', 'LLC', 'LLP', 'Holdings', 'Group', 'Corp', 'Corporation', 'Services',
-            'Enterprises', 'Solutions', 'Global', 'Ventures', 'Industries', 'Integrators', 'Associates', 'Incorporated', 'Partners',
-            'Resources', 'Technologies', 'Logistics', 'Management', 'Consulting', 'Enterprises', 'Solutions', 'Group', 'Industries',
-            'Systems', 'Enterprises', 'Holdings', 'Development', 'Sustainable', 'Enterprises', 'Innovations', 'Foundation'
-
-        ];
-
-        $prefix = $prefixes[rand(0, count($prefixes) - 1)];
-        $suffix = $suffixes[rand(0, count($suffixes) - 1)];
-
-        return "$prefix $suffix";
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -447,8 +430,50 @@ class SenegalFakerGenerator extends BaseGenerator implements FakerGeneratorInter
     
         // Sélection aléatoire d'un nom de plat sénégalais
         $nomPlat = $platsSenegalais[array_rand($platsSenegalais)];
-    
+
         return $nomPlat;
     }
-    
+
+    public function university()
+    {
+        $universities = [
+            'Université Cheikh Anta Diop (UCAD) de Dakar',
+            'Université Gaston Berger (UGB) de Saint-Louis',
+            'Université de Ziguinchor', 'Université Alioune Diop de Bambey',
+            'Université Assane Seck de Ziguinchor',
+            'École Supérieure Polytechnique (ESP)',
+            'Institut Supérieur de Management (ISM)',
+            'Université du Sahel', 'École Nationale Supérieure d\'Agriculture (ENSA)',
+            'Institut Africain de Management (IAM)',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Plateau', 'Médina', 'Grand Dakar', 'Parcelles Assainies',
+            'Ouakam', 'Ngor', 'Almadies', 'Yoff', 'Sacré-Cœur',
+            'Point E', 'Fann', 'Liberté', 'HLM', 'Grand Yoff',
+            'Pikine', 'Guédiawaye', 'Dieuppeul', 'Derklé',
+            'Mermoz', 'Sicap', 'Fenêtre Mermoz', 'Hlm Grand Yoff',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $regions = ['DK', 'TH', 'KL', 'ZG', 'SL', 'LG', 'FK', 'KD', 'MT', 'TC'];
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $region = $regions[array_rand($regions)];
+        $number = str_pad(rand(1, 9999), 4, '0', STR_PAD_LEFT);
+        $suffix = $letters[rand(0, strlen($letters) - 1)];
+        return $region . ' ' . $number . ' ' . $suffix;
+    }
+
+    public function nationalId()
+    {
+        $year = rand(70, 99);
+        return '1' . $year . str_pad(rand(1, 9999999999999), 11, '0', STR_PAD_LEFT);
+    }
 }

--- a/src/Country/Africa/SouthAfricaFakerGenerator.php
+++ b/src/Country/Africa/SouthAfricaFakerGenerator.php
@@ -214,21 +214,17 @@ public function address()
     return "$randomNeighborhood, $randomCity";
 }    
 
-public function phone()
-{
-    $prefixes = ['+27(0)60', '+27(0)61', '+27(0)62', '+27(0)63', '+27(0)64', '+27(0)65', '+27(0)66', '+27(0)67', '+27(0)68', '+27(0)69'];
-    
-    // Choisissez un préfixe téléphonique aléatoire parmi les indicatifs de réseau mobile en Afrique du Sud
-    $randomPrefix = $prefixes[array_rand($prefixes)];
-    
-    // Générez les 7 derniers chiffres aléatoires
-    $secondPart = '';
-    for ($i = 0; $i < 7; $i++) {
-        $secondPart .= rand(0, 9);
+    public function phone()
+    {
+        $prefixes = [
+            '082', '072', '060',  // Vodacom
+            '083', '073', '063',  // MTN SA
+            '084', '074', '064',  // Cell C
+            '081', '071',         // Telkom Mobile
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+27 %s %03d %04d', $prefix, rand(100, 999), rand(1000, 9999));
     }
-    
-    return $randomPrefix . $secondPart;
-}
 
     
     public function email()
@@ -262,26 +258,16 @@ public function phone()
 
     public function companyName()
     {
-        $prefixes = [
-            'Safika', 'Barloworld', 'Naspers', 'Bidvest', 'Remgro', 'Sasol', 'Anglo American', 'Sanlam', 'Standard Bank', 'Old Mutual',
-            'MTN Group', 'Shoprite Holdings', 'Vodacom Group', 'Tiger Brands', 'Aspen Pharmacare', 'Investec', 'Imperial Logistics', 'Mediclinic International', 'BHP', 'Gold Fields',
-            'Sibanye-Stillwater', 'AngloGold Ashanti', 'Exxaro Resources', 'Sappi', 'Mr Price Group', 'Woolworths Holdings', 'Netcare', 'Telkom Group', 'Life Healthcare', 'Pick n Pay Stores',
-            'Clicks Group', 'Truworths International', 'Adcock Ingram Holdings', 'RMB Holdings', 'Reinet Investments', 'Massmart Holdings', 'Redefine Properties', 'Remgro', 'Bidcorp', 'Growthpoint Properties',
-            'Capitec Bank Holdings', 'Kumba Iron Ore', 'Barclays Africa Group', 'RMB Holdings', 'Reinet Investments', 'Massmart Holdings', 'Redefine Properties', 'Bidcorp', 'Growthpoint Properties', 'Capitec Bank Holdings',
-            'Kumba Iron Ore', 'Barclays Africa Group', 'Telkom Group', 'Nampak', 'Impala Platinum Holdings', 'Sanlam', 'Steinhoff International Holdings', 'Exxaro Resources', 'Netcare', 'Hosken Consolidated Investments',
-            'Coronation Fund Managers', 'Murray & Roberts Holdings', 'AVI', 'Liberty Holdings', 'Reunert', 'Pioneer Foods Group', 'Exxaro Resources', 'RMB Holdings', 'Mondi', 'Shoprite Holdings', 'Anglo American Platinum',
-            'Datatec', 'Vukile Property Fund', 'Redefine Properties', 'Woolworths Holdings', 'Sasol', 'BHP', 'Barloworld', 'Sanlam', 'Bidvest', 'Remgro', 'Sappi', 'Anglo American Platinum', 'Tiger Brands', 'Nedbank Group'
+        $companies = [
+            'MTN South Africa', 'Vodacom', 'Cell C', 'Telkom SA',
+            'Standard Bank', 'FNB', 'ABSA', 'Nedbank', 'Capitec Bank',
+            'Discovery', 'Old Mutual', 'Sanlam', 'Momentum Metropolitan',
+            'Pick n Pay', 'Shoprite', 'Woolworths SA', 'Checkers', 'Clicks',
+            'Anglo American', 'De Beers', 'Sasol', 'Eskom', 'Transnet',
+            'Bidvest', 'Remgro', 'Naspers', 'MultiChoice', 'Tiger Brands',
+            'Aspen Pharmacare', 'AngloGold Ashanti', 'Sibanye-Stillwater',
         ];
-    
-        $suffixes = [
-            'Ltd', 'PLC', 'LLC', 'Limited', 'Holdings', 'Group', 'Corp', 'Corporation', 'Services', 'Enterprises', 'Solutions', 'Global', 'Ventures', 'Industries', 'Integrators', 'Associates', 'Incorporated',
-            'Partners', 'Resources', 'Technologies', 'Logistics', 'Management', 'Consulting', 'Enterprises', 'Solutions', 'Group', 'Industries', 'Systems', 'Enterprises', 'Holdings', 'Development', 'Foundation'
-        ];
-    
-        $prefix = $prefixes[rand(0, count($prefixes) - 1)];
-        $suffix = $suffixes[rand(0, count($suffixes) - 1)];
-    
-        return "$prefix $suffix";
+        return $companies[array_rand($companies)];
     }
     
     public function creditCardNumber()
@@ -423,6 +409,50 @@ public function phone()
     
         return $nomPlat;
     }
-    
-    
+
+    public function university()
+    {
+        $universities = [
+            'University of Cape Town (UCT)', 'University of the Witwatersrand (Wits)',
+            'Stellenbosch University', 'University of Pretoria (UP)',
+            'University of KwaZulu-Natal (UKZN)', 'Rhodes University',
+            'University of Johannesburg (UJ)', 'University of the Western Cape (UWC)',
+            'UNISA', 'North-West University (NWU)', 'University of Limpopo',
+            'University of the Free State', 'Nelson Mandela University',
+            'Cape Peninsula University of Technology (CPUT)',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Sandton', 'Soweto', 'Rosebank', 'Melville', 'Fourways',
+            'Midrand', 'Centurion', 'Hatfield', 'Sunnyside', 'Arcadia',
+            'Sea Point', 'Green Point', 'Camps Bay', 'Observatory', 'Woodstock',
+            'Claremont', 'Kenilworth', 'Umhlanga', 'Berea', 'Morningside',
+            'Hillcrest', 'Ballito', 'Durban North', 'Pinetown', 'Westville',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $provinces = ['GP', 'WC', 'KZN', 'EC', 'LP', 'MP', 'NC', 'NW', 'FS'];
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $province = $provinces[array_rand($provinces)];
+        $l1 = $letters[rand(0, strlen($letters) - 1)];
+        $l2 = $letters[rand(0, strlen($letters) - 1)];
+        $number = rand(100, 999);
+        return $province . ' ' . $l1 . $l2 . ' ' . $number;
+    }
+
+    public function nationalId()
+    {
+        $year  = str_pad(rand(50, 99), 2, '0', STR_PAD_LEFT);
+        $month = str_pad(rand(1, 12), 2, '0', STR_PAD_LEFT);
+        $day   = str_pad(rand(1, 28), 2, '0', STR_PAD_LEFT);
+        $seq   = str_pad(rand(0, 9999), 4, '0', STR_PAD_LEFT);
+        return $year . $month . $day . $seq . '08' . rand(0, 9);
+    }
 }

--- a/src/Country/America/CanadaFakerGenerator.php
+++ b/src/Country/America/CanadaFakerGenerator.php
@@ -256,15 +256,20 @@ class CanadaFakerGenerator extends BaseGenerator implements FakerGeneratorInterf
 
     public function phone()
     {
-        $prefix = '+1'; // Préfixe international pour le Canada
-
-        // Générez les 10 chiffres suivants aléatoirement
-        $phoneDigits = '';
-        for ($i = 0; $i < 10; $i++) {
-            $phoneDigits .= rand(0, 9);
-        }
-
-        return $prefix . $phoneDigits;
+        $areaCodes = [
+            '604', '778', '250', '236',  // British Columbia
+            '403', '780', '587',         // Alberta
+            '306', '639',                // Saskatchewan
+            '204', '431',                // Manitoba
+            '416', '647', '437', '905', '289', '365',  // Ontario (Toronto)
+            '613', '343',                // Ontario (Ottawa)
+            '514', '438', '450', '579',  // Québec (Montréal)
+            '418', '581', '367',         // Québec (Québec)
+            '902', '782',                // Nova Scotia / PEI
+            '506',                       // New Brunswick
+        ];
+        $area = $areaCodes[array_rand($areaCodes)];
+        return sprintf('+1 (%s) %03d-%04d', $area, rand(200, 999), rand(1000, 9999));
     }
 
     public function email()
@@ -481,5 +486,52 @@ class CanadaFakerGenerator extends BaseGenerator implements FakerGeneratorInterf
         $nomPlat = $platsCanadiens[array_rand($platsCanadiens)];
 
         return $nomPlat;
+    }
+
+    public function university()
+    {
+        $universities = [
+            'University of Toronto', 'McGill University',
+            'University of British Columbia (UBC)', 'University of Alberta',
+            'Université de Montréal', 'University of Ottawa', 'Queen\'s University',
+            'Western University', 'McMaster University', 'Simon Fraser University',
+            'Dalhousie University', 'Université Laval', 'York University',
+            'University of Calgary', 'University of Manitoba',
+            'Carleton University', 'Concordia University', 'University of Waterloo',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Downtown Toronto', 'North York', 'Scarborough', 'Etobicoke', 'Mississauga',
+            'Brampton', 'Markham', 'Richmond Hill', 'Oakville', 'Burlington',
+            'Plateau-Mont-Royal', 'Côte-des-Neiges', 'Rosemont', 'Outremont', 'Westmount',
+            'NDG', 'Laval', 'Longueuil', 'Brossard', 'Saint-Laurent',
+            'Downtown Vancouver', 'Burnaby', 'Surrey', 'Richmond BC', 'Coquitlam',
+            'West End Vancouver', 'Kitsilano', 'Commercial Drive',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $formats = [
+            'ON' => fn() => strtoupper(substr(str_shuffle('ABCDEFGHJKLMNPRSTUVWXYZ'), 0, 4)) . ' ' . rand(100, 999),
+            'QC' => fn() => strtoupper(substr(str_shuffle('ABCDEFGHJKLMNPRSTUVWXYZ'), 0, 3)) . ' ' . rand(1000, 9999),
+            'BC' => fn() => strtoupper(substr(str_shuffle('ABCDEFGHJKLMNPRSTUVWXYZ'), 0, 3)) . ' ' . rand(100, 999),
+            'AB' => fn() => strtoupper(substr(str_shuffle('ABCDEFGHJKLMNPRSTUVWXYZ'), 0, 3)) . ' ' . rand(1000, 9999),
+        ];
+        $province = array_rand($formats);
+        return $province . ' ' . ($formats[$province])();
+    }
+
+    public function nationalId()
+    {
+        $part1 = str_pad(rand(100, 999), 3, '0', STR_PAD_LEFT);
+        $part2 = str_pad(rand(100, 999), 3, '0', STR_PAD_LEFT);
+        $part3 = str_pad(rand(100, 999), 3, '0', STR_PAD_LEFT);
+        return $part1 . '-' . $part2 . '-' . $part3;
     }
 }

--- a/src/Country/America/UnitedStatesFakerGenerator.php
+++ b/src/Country/America/UnitedStatesFakerGenerator.php
@@ -250,19 +250,24 @@ class UnitedStatesFakerGenerator extends BaseGenerator implements FakerGenerator
 
     public function phone()
     {
-        $prefix = '+1';
-
-        // Generate the first digit randomly from 2 to 9
-        $firstDigit = rand(2, 9);
-
-
-        // Générez les 5 derniers chiffres aléatoires
-        $secondPart = '';
-        for ($i = 0; $i < 9; $i++) {
-            $secondPart .= rand(0, 9);
-        }
-
-        return $prefix . $firstDigit  . $secondPart;
+        $areaCodes = [
+            '212', '646', '718', '917', '332',  // New York City
+            '213', '310', '323', '424', '747',  // Los Angeles
+            '312', '773', '872',                // Chicago
+            '713', '281', '832', '346',         // Houston
+            '602', '480', '623',                // Phoenix
+            '215', '267', '445',                // Philadelphia
+            '210', '726',                       // San Antonio
+            '619', '858', '442',                // San Diego
+            '214', '469', '972', '945',         // Dallas
+            '408', '669',                       // San Jose
+            '512', '737',                       // Austin
+            '415', '628',                       // San Francisco
+            '614', '380',                       // Columbus
+            '704', '980',                       // Charlotte
+        ];
+        $area = $areaCodes[array_rand($areaCodes)];
+        return sprintf('+1 (%s) %03d-%04d', $area, rand(200, 999), rand(1000, 9999));
     }
 
     public function email()
@@ -296,13 +301,15 @@ class UnitedStatesFakerGenerator extends BaseGenerator implements FakerGenerator
 
     public function companyName()
     {
-        $prefixes = ['ABC', 'XYZ', 'Tech', 'First', 'Global', 'National', 'United', 'Innovative', 'American', 'Century', 'City', 'Strategic', 'Dynamic', 'Capital', 'Quality', 'Pioneer', 'Advanced', 'Frontier', 'Pro', 'Star', 'Peak', 'Worldwide', 'Blue', 'Green', 'Red', 'Yellow'];
-        $suffixes = ['Inc', 'Corp', 'Group', 'Enterprises', 'Solutions', 'Industries', 'Incorporated', 'Services', 'International', 'Systems', 'Holdings', 'Enterprises', 'Associates', 'Ventures', 'Management', 'Partners', 'Technologies', 'Logistics', 'Consulting', 'Network', 'Innovations', 'America', 'Global', 'World', 'United', 'Enterprize'];
-
-        $prefix = $prefixes[rand(0, count($prefixes) - 1)];
-        $suffix = $suffixes[rand(0, count($suffixes) - 1)];
-
-        return "$prefix $suffix";
+        $companies = [
+            'Apple', 'Microsoft', 'Google', 'Amazon', 'Meta', 'Tesla', 'Nvidia',
+            'Walmart', 'JPMorgan Chase', 'Bank of America', 'Wells Fargo', 'Citigroup',
+            'ExxonMobil', 'Chevron', 'Johnson & Johnson', 'Pfizer', 'UnitedHealth Group',
+            'Coca-Cola', 'PepsiCo', 'McDonald\'s', 'Starbucks', 'Nike', 'Disney',
+            'Netflix', 'AT&T', 'Verizon', 'Visa', 'Mastercard', 'Goldman Sachs',
+            'Morgan Stanley', 'Berkshire Hathaway', 'Home Depot', 'Procter & Gamble',
+        ];
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -416,8 +423,51 @@ class UnitedStatesFakerGenerator extends BaseGenerator implements FakerGenerator
     
         // Sélection aléatoire d'un nom de plat
         $nomPlat = $platsUs[array_rand($platsUs)];
-    
+
         return $nomPlat;
     }
-    
+
+    public function university()
+    {
+        $universities = [
+            'Harvard University', 'MIT', 'Stanford University', 'Yale University',
+            'Princeton University', 'Columbia University', 'University of Chicago',
+            'Duke University', 'University of Pennsylvania', 'Dartmouth College',
+            'Brown University', 'Cornell University', 'UC Berkeley', 'UCLA',
+            'NYU', 'USC', 'University of Michigan', 'University of Texas at Austin',
+            'Georgetown University', 'Notre Dame University', 'Johns Hopkins University',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Manhattan', 'Brooklyn', 'Queens', 'The Bronx', 'Staten Island',
+            'Beverly Hills', 'Hollywood', 'Santa Monica', 'Venice Beach', 'Malibu',
+            'Lincoln Park', 'Logan Square', 'Wicker Park', 'River North', 'Gold Coast',
+            'Midtown', 'Upper East Side', 'Harlem', 'SoHo', 'Tribeca',
+            'Georgetown', 'Dupont Circle', 'Adams Morgan', 'Capitol Hill',
+            'Mission District', 'Nob Hill', 'Haight-Ashbury', 'Castro',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $l1 = $letters[rand(0, strlen($letters) - 1)];
+        $l2 = $letters[rand(0, strlen($letters) - 1)];
+        $l3 = $letters[rand(0, strlen($letters) - 1)];
+        return $l1 . $l2 . $l3 . '-' . rand(1000, 9999);
+    }
+
+    public function nationalId()
+    {
+        $area   = str_pad(rand(1, 899), 3, '0', STR_PAD_LEFT);
+        if ($area === '666') $area = '667';
+        $group  = str_pad(rand(1, 99), 2, '0', STR_PAD_LEFT);
+        $serial = str_pad(rand(1, 9999), 4, '0', STR_PAD_LEFT);
+        return $area . '-' . $group . '-' . $serial;
+    }
 }

--- a/src/Country/Europe/FranceFakerGenerator.php
+++ b/src/Country/Europe/FranceFakerGenerator.php
@@ -150,14 +150,15 @@ class FranceFakerGenerator extends BaseGenerator implements FakerGeneratorInterf
 
     public function phone()
     {
-        $first = [6, 7, 9][rand(0, 2)];
-        $rest  = '';
-
-        for ($i = 0; $i < 8; $i++) {
-            $rest .= rand(0, 9);
-        }
-
-        return '+33' . $first . $rest;
+        $prefixes = [
+            '06 1', '06 2', '06 8',   // Orange
+            '06 3', '06 7',            // SFR
+            '06 6', '06 9',            // Bouygues
+            '06 5', '07 5',            // Free Mobile
+            '07 6', '07 8',            // autres
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+33 %s %02d %02d %02d %02d', $prefix, rand(10, 99), rand(10, 99), rand(10, 99), rand(10, 99));
     }
 
     public function email()
@@ -184,19 +185,16 @@ class FranceFakerGenerator extends BaseGenerator implements FakerGeneratorInterf
 
     public function companyName()
     {
-        $prefixes = [
-            'Air France', 'Total', 'L\'Oréal', 'BNP Paribas', 'Renault', 'AXA', 'Dassault Systèmes', 'Capgemini',
-            'Sanofi', 'LVMH', 'Société Générale', 'Orange', 'Danone', 'Schneider Electric', 'Thales', 'Saint-Gobain',
-            'Carrefour', 'Publicis', 'Michelin', 'Airbus', 'Veolia', 'Sodexo', 'Alstom', 'Engie', 'Hermès',
-            'Safran', 'EssilorLuxottica', 'Vinci', 'Peugeot', 'Eiffage', 'Bouygues', 'Kering', 'Accor', 'EDF',
-            'Air Liquide', 'Suez', 'Arkema', 'Ubisoft', 'Valeo', 'Legrand',
+        $companies = [
+            'LVMH', 'TotalEnergies', 'BNP Paribas', 'AXA', 'Société Générale',
+            'Crédit Agricole', 'Carrefour', 'EDF', 'Engie', 'Sanofi',
+            'L\'Oréal', 'Michelin', 'Airbus', 'Renault', 'Stellantis',
+            'Dassault Aviation', 'Thales', 'Safran', 'Schneider Electric',
+            'Capgemini', 'Orange SA', 'Vivendi', 'Canal+', 'CMA CGM',
+            'Air France-KLM', 'Danone', 'Kering', 'Hermès', 'Publicis Groupe',
+            'Vinci', 'Bouygues', 'Eiffage', 'Veolia', 'Air Liquide',
         ];
-
-        $suffixes = [
-            'SA', 'SAS', 'SARL', 'Group', 'Corp', 'Holdings', 'Solutions', 'Services', 'Ventures', 'Industries',
-        ];
-
-        return $prefixes[array_rand($prefixes)] . ' ' . $suffixes[array_rand($suffixes)];
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -249,5 +247,53 @@ class FranceFakerGenerator extends BaseGenerator implements FakerGeneratorInterf
         ];
 
         return $plats[array_rand($plats)];
+    }
+
+    public function university()
+    {
+        $universities = [
+            'Université Paris-Sorbonne (Paris IV)', 'Université Paris Cité',
+            'Sciences Po Paris', 'HEC Paris', 'École Polytechnique',
+            'ENS Paris', 'ESSEC Business School', 'INSEAD', 'Centrale Paris',
+            'Mines Paris', 'Télécom Paris', 'ESCP Business School',
+            'Université de Lyon I', 'Université de Bordeaux',
+            'Université Paul Sabatier (Toulouse III)', 'Université Aix-Marseille',
+            'Université de Strasbourg', 'Université de Lille',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Le Marais', 'Saint-Germain-des-Prés', 'Montmartre', 'Bastille',
+            'Belleville', 'République', 'Oberkampf', 'Canal Saint-Martin',
+            'La Défense', 'Neuilly-sur-Seine', 'Boulogne-Billancourt',
+            'Levallois-Perret', 'Issy-les-Moulineaux', 'Vincennes',
+            'Montreuil', 'Pantin', 'Saint-Denis', 'Aubervilliers',
+            'Part-Dieu', 'Confluence', 'Vieux-Port', 'Préfecture',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $l1 = $letters[rand(0, strlen($letters) - 1)];
+        $l2 = $letters[rand(0, strlen($letters) - 1)];
+        $l3 = $letters[rand(0, strlen($letters) - 1)];
+        $l4 = $letters[rand(0, strlen($letters) - 1)];
+        return $l1 . $l2 . '-' . rand(100, 999) . '-' . $l3 . $l4;
+    }
+
+    public function nationalId()
+    {
+        $sex  = rand(1, 2);
+        $year = str_pad(rand(50, 99), 2, '0', STR_PAD_LEFT);
+        $month = str_pad(rand(1, 12), 2, '0', STR_PAD_LEFT);
+        $dept = str_pad(rand(1, 95), 2, '0', STR_PAD_LEFT);
+        $order = str_pad(rand(1, 999), 3, '0', STR_PAD_LEFT);
+        $key  = str_pad(rand(1, 97), 2, '0', STR_PAD_LEFT);
+        return $sex . ' ' . $year . ' ' . $month . ' ' . $dept . ' ' . $order . ' ' . $key;
     }
 }

--- a/src/Country/Europe/GermanyFakerGenerator.php
+++ b/src/Country/Europe/GermanyFakerGenerator.php
@@ -276,18 +276,14 @@ class GermanyFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function phone()
     {
-        $prefix = '+49'; // Germany country code
-
-        // Generate the first digit randomly from 1 to 9
-        $firstDigit = rand(1, 9);
-
-        // Generate the following 10 digits randomly
-        $secondPart = '';
-        for ($i = 0; $i < 10; $i++) {
-            $secondPart .= rand(0, 9);
-        }
-
-        return $prefix . $firstDigit  . $secondPart;
+        $prefixes = [
+            '0151', '0160', '0170', '0171', '0175',  // Telekom
+            '0152', '0162', '0172', '0173', '0174',  // Vodafone
+            '0176', '0177', '0178', '0179',          // O2
+            '0157', '0163',                          // 1&1 / Drillisch
+        ];
+        $prefix = $prefixes[array_rand($prefixes)];
+        return sprintf('+49 %s %07d', $prefix, rand(1000000, 9999999));
     }
 
 
@@ -322,13 +318,15 @@ class GermanyFakerGenerator extends BaseGenerator implements FakerGeneratorInter
 
     public function companyName()
     {
-        $prefixes = ['Firma', 'Unternehmen', 'Gruppe', 'Gesellschaft', 'AG', 'GmbH', 'KG', 'OHG'];
-        $suffixes = ['& Co.', 'e.K.', 'mbH', 'AG', 'UG', 'KGaA', 'eG'];
-
-        $prefix = $prefixes[rand(0, count($prefixes) - 1)];
-        $suffix = $suffixes[rand(0, count($suffixes) - 1)];
-
-        return "$prefix $suffix";
+        $companies = [
+            'Volkswagen AG', 'BMW AG', 'Mercedes-Benz Group', 'Siemens AG', 'SAP SE',
+            'Deutsche Telekom', 'Deutsche Bank', 'Allianz SE', 'Munich Re', 'BASF SE',
+            'Bayer AG', 'Henkel AG', 'adidas AG', 'Puma SE', 'Bosch GmbH',
+            'Continental AG', 'Thyssenkrupp', 'E.ON SE', 'RWE AG', 'Lufthansa AG',
+            'Deutsche Post DHL', 'Zalando SE', 'Lidl', 'Aldi', 'REWE Group',
+            'Otto GmbH', 'Infineon Technologies', 'LANXESS', 'Covestro AG',
+        ];
+        return $companies[array_rand($companies)];
     }
 
     public function creditCardNumber()
@@ -444,8 +442,60 @@ class GermanyFakerGenerator extends BaseGenerator implements FakerGeneratorInter
     
         // Sélection aléatoire d'un nom de plat
         $nomPlat = $platsGermany[array_rand($platsGermany)];
-    
+
         return $nomPlat;
     }
 
+    public function university()
+    {
+        $universities = [
+            'Ludwig-Maximilians-Universität München (LMU)',
+            'Technische Universität München (TUM)',
+            'Ruprecht-Karls-Universität Heidelberg',
+            'Humboldt-Universität zu Berlin',
+            'Freie Universität Berlin',
+            'RWTH Aachen University',
+            'Universität Hamburg',
+            'Goethe-Universität Frankfurt',
+            'Universität Stuttgart',
+            'Albert-Ludwigs-Universität Freiburg',
+            'Technische Universität Berlin (TU Berlin)',
+            'Karlsruher Institut für Technologie (KIT)',
+            'Universität Mannheim', 'Georg-August-Universität Göttingen',
+            'Westfälische Wilhelms-Universität Münster',
+        ];
+        return $universities[array_rand($universities)];
+    }
+
+    public function district()
+    {
+        $districts = [
+            'Mitte', 'Prenzlauer Berg', 'Friedrichshain', 'Kreuzberg',
+            'Charlottenburg', 'Wilmersdorf', 'Schöneberg', 'Neukölln',
+            'Wedding', 'Pankow', 'Steglitz', 'Zehlendorf',
+            'Schwabing', 'Maxvorstadt', 'Bogenhausen', 'Haidhausen',
+            'Altstadt', 'Lehel', 'Giesing', 'Pasing',
+            'Altstadt Hamburg', 'Eimsbüttel', 'Eppendorf', 'Barmbek',
+        ];
+        return $districts[array_rand($districts)];
+    }
+
+    public function licensePlate()
+    {
+        $cities = ['B', 'M', 'HH', 'K', 'F', 'S', 'DU', 'DO', 'L', 'DD', 'HB', 'NÜ', 'MA', 'BO', 'WI'];
+        $letters = 'ABCDEFGHJKLMNPRSTUVWXYZ';
+        $city = $cities[array_rand($cities)];
+        $l1 = $letters[rand(0, strlen($letters) - 1)];
+        $l2 = $letters[rand(0, strlen($letters) - 1)];
+        $number = rand(1, 9999);
+        return $city . ' ' . $l1 . $l2 . ' ' . $number;
+    }
+
+    public function nationalId()
+    {
+        $letter = chr(rand(65, 90));
+        $digits = str_pad(rand(10000000, 99999999), 8, '0', STR_PAD_LEFT);
+        $check  = rand(0, 9);
+        return $letter . $digits . $check;
+    }
 }

--- a/tests/GeneratorContractTest.php
+++ b/tests/GeneratorContractTest.php
@@ -111,4 +111,59 @@ class GeneratorContractTest extends TestCase
         $this->assertIsString($result);
         $this->assertNotEmpty($result);
     }
+
+    /**
+     * @dataProvider generatorProvider
+     */
+    public function test_university_returns_non_empty_string(string $class): void
+    {
+        $generator = new $class();
+        $result = $generator->university();
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * @dataProvider generatorProvider
+     */
+    public function test_district_returns_non_empty_string(string $class): void
+    {
+        $generator = new $class();
+        $result = $generator->district();
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * @dataProvider generatorProvider
+     */
+    public function test_license_plate_returns_non_empty_string(string $class): void
+    {
+        $generator = new $class();
+        $result = $generator->licensePlate();
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * @dataProvider generatorProvider
+     */
+    public function test_national_id_returns_non_empty_string(string $class): void
+    {
+        $generator = new $class();
+        $result = $generator->nationalId();
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /**
+     * @dataProvider generatorProvider
+     */
+    public function test_company_name_returns_non_empty_string(string $class): void
+    {
+        $generator = new $class();
+        $result = $generator->companyName();
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
 }


### PR DESCRIPTION
…+ real phone prefixes

Adds 4 new methods to all 9 country generators:
- university(): real local universities
- district(): real local neighborhoods
- licensePlate(): country/region-specific plate formats
- nationalId(): realistic ID formats (NIN, SSN, SIN, NIR, CNI...)

Also rewrites phone() to use real operator prefixes (MTN 650-679, Orange 690-699, Nexttel 660-669 for Cameroon; 0803/0806 MTN for Nigeria; 77/78 Orange SN for Senegal; real area codes for US/Canada; Telekom/ Vodafone/O2 prefixes for Germany; etc.) and updates companyName() with real local companies for all 9 countries.

Tests: 117/117 (was 72/72).